### PR TITLE
v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 
+
+## [0.8.0] - 2024-04-21
+### Added
+ - Added support for TLS 1.3
+
+### Changed
+ - Improved the reproducibility of the release build
+
 ## [0.7.1] - 2021-11-04
 ### Fixed
  - The current selection could be lost if the entry list was refreshed after performing a HIBP search
@@ -55,7 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Check HIBP Pnwed Passwords service when an entry gets modified (optional)
  - Big thanks to [Troy Hunt] and [Junade Ali] who make this possible!
 
-[Unreleased]: https://github.com/kapsiR/HaveIBeenPwnedKeePassPlugin/compare/v0.7.1...HEAD
+[Unreleased]: https://github.com/kapsiR/HaveIBeenPwnedKeePassPlugin/compare/v0.8.0...HEAD
+[0.7.1]: https://github.com/kapsiR/HaveIBeenPwnedKeePassPlugin/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/kapsiR/HaveIBeenPwnedKeePassPlugin/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/kapsiR/HaveIBeenPwnedKeePassPlugin/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/kapsiR/HaveIBeenPwnedKeePassPlugin/compare/v0.5.0...v0.6.0

--- a/HaveIBeenPwnedKeePassPlugin.sln
+++ b/HaveIBeenPwnedKeePassPlugin.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29613.14
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34728.123
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8853044B-7D95-4B20-965D-08E2454F781F}"
 	ProjectSection(SolutionItems) = preProject

--- a/HaveIBeenPwnedKeePassPlugin/Directory.Build.props
+++ b/HaveIBeenPwnedKeePassPlugin/Directory.Build.props
@@ -6,4 +6,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
+  <PropertyGroup>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <PathMap>$(MSBuildProjectDirectory)=./$(MsBuildProjectName)/</PathMap>
+  </PropertyGroup>
 </Project>

--- a/HaveIBeenPwnedKeePassPlugin/HaveIBeenPwnedPlugin.csproj
+++ b/HaveIBeenPwnedKeePassPlugin/HaveIBeenPwnedPlugin.csproj
@@ -12,7 +12,6 @@
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -53,6 +52,9 @@
   </ItemGroup>
   <ItemGroup>
     <WCFMetadata Include="Connected Services\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Directory.Build.props" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/HaveIBeenPwnedKeePassPlugin/HaveIBeenPwnedPlugin.csproj
+++ b/HaveIBeenPwnedKeePassPlugin/HaveIBeenPwnedPlugin.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\KeePass-2.X\Plugins\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
@@ -23,12 +23,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>embedded</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="KeePass">

--- a/HaveIBeenPwnedKeePassPlugin/HaveIBeenPwnedPluginExt.cs
+++ b/HaveIBeenPwnedKeePassPlugin/HaveIBeenPwnedPluginExt.cs
@@ -53,7 +53,12 @@ namespace HaveIBeenPwnedPlugin
             {
                 // Supported protocols for HIBP are >= TLS 1.2
                 // https://haveibeenpwned.com/API/v2#HTTPS
-                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
+                // We want to enforce secure defaults, hence we don't rely on SecurityProtocolType.SystemDefault
+                // TLS 1.3 is supported since Windows Server 2022 / Windows 11, version 21H2
+                // The enum value for TLS 1.3 (0x3000) has been added in .NET Framework 4.8
+                // Since we target 4.7.2, we use it directly as value
+                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | (SecurityProtocolType)12288;
             }
             catch (NotSupportedException)
             {

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.7.1",
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "0.8.0",
   "publicReleaseRefSpec": [
     "^refs/heads/master$"
   ],


### PR DESCRIPTION
- Bump version to v0.8.0
- Add support for TLS 1.3
- Change debug symbols to the portable PDB format
- Configure path map for release builds